### PR TITLE
Add Botany Pots recipes for BYG trees

### DIFF
--- a/kubejs/server_scripts/botany_pots.js
+++ b/kubejs/server_scripts/botany_pots.js
@@ -510,7 +510,7 @@ events.listen('recipes', function (e) {
         })
     }
 
-    function growTreeExtra(mod, name, extra) {
+    function growTreeExtra(mod, name, ...extra) {
         e.recipes.botanypots.crop({
             seed: {
                 item: mod + ':' + name + '_sapling'
@@ -546,12 +546,12 @@ events.listen('recipes', function (e) {
                     minRolls: 1,
                     maxRolls: 2
                 },
-                extra
+                ...extra
             ]
         })
     }
 
-    function growTreeExtraBoP(mod, name, extra) {
+    function growTreeExtraBoP(mod, name, ...extra) {
         e.recipes.botanypots.crop({
             seed: {
                 item: mod + ':' + name + '_sapling'
@@ -579,7 +579,7 @@ events.listen('recipes', function (e) {
                     minRolls: 1,
                     maxRolls: 2
                 },
-                extra
+                ...extra
             ]
         })
     }

--- a/kubejs/server_scripts/botany_pots.js
+++ b/kubejs/server_scripts/botany_pots.js
@@ -757,6 +757,211 @@ events.listen('recipes', function (e) {
         maxRolls: 1
     })
 
+    // Biomes You'll Go trees
+    growTree('byg', 'aspen')
+    growTree('byg', 'baobab')
+    growTree('byg', 'blue_enchanted')
+    growTreeExtraBoP('byg', 'pink_cherry', {
+        chance: 0.50,
+        output: {
+            item: 'byg:cherry_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'white_cherry', {
+        chance: 0.50,
+        output: {
+            item: 'byg:cherry_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTree('byg', 'cika')
+    growTree('byg', 'cypress')
+    growTree('byg', 'ebony')
+    growTree('byg', 'fir')
+    growTree('byg', 'green_enchanted')
+    growTreeExtra('byg', 'holly', {
+        chance: 0.01,
+        output: {
+            item: 'byg:holly_berries'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTree('byg', 'jacaranda')
+    growTreeExtraBoP('byg', 'indigo_jacaranda', {
+        chance: 0.50,
+        output: {
+            item: 'byg:jacaranda_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTree('byg', 'mahogany')
+    growTree('byg', 'mangrove')
+    growTree('byg', 'maple')
+    growTreeExtraBoP('byg', 'red_maple', {
+        chance: 0.50,
+        output: {
+            item: 'byg:maple_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'silver_maple', {
+        chance: 0.50,
+        output: {
+            item: 'byg:maple_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTree('byg', 'palo_verde')
+    growTree('byg', 'pine')
+    growTree('byg', 'rainbow_eucalyptus')
+    growTree('byg', 'redwood')
+    growTreeExtra('byg', 'skyris', {
+        chance: 0.01,
+        output: {
+            item: 'byg:green_apple'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTree('byg', 'willow')
+    growTree('byg', 'witch_hazel')
+    growTree('byg', 'zelkova')
+    growTreeExtraBoP('byg', 'blue_spruce', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:spruce_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'brown_birch', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:birch_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'brown_oak', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:dark_oak_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'joshua', {
+                chance: 0.50,
+                output: {
+                    item: 'minecraft:oak_log'
+                },
+                minRolls: 1,
+                maxRolls: 1
+            },
+            {
+                chance: 0.01,
+                output: {
+                    item: 'byg:joshua_fruit'
+                },
+                minRolls: 1,
+                maxRolls: 1
+            })
+    growTreeExtraBoP('byg', 'orange_birch', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:birch_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'orange_oak', {
+                chance: 0.50,
+                output: {
+                    item: 'minecraft:oak_log'
+                },
+                minRolls: 1,
+                maxRolls: 1
+            },
+            {
+                chance: 0.01,
+                output: {
+                    item: 'minecraft:apple'
+                },
+                minRolls: 1,
+                maxRolls: 1
+            })
+    growTreeExtraBoP('byg', 'orange_spruce', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:spruce_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'orchard', {
+                chance: 0.50,
+                output: {
+                    item: 'minecraft:oak_log'
+                },
+                minRolls: 1,
+                maxRolls: 1
+            },
+            {
+                chance: 0.50,
+                output: {
+                    item: 'minecraft:apple'
+                },
+                minRolls: 1,
+                maxRolls: 1
+            })
+    growTreeExtraBoP('byg', 'red_birch', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:birch_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'red_oak', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:oak_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'red_spruce', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:spruce_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'yellow_birch', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:birch_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+    growTreeExtraBoP('byg', 'yellow_spruce', {
+        chance: 0.50,
+        output: {
+            item: 'minecraft:spruce_log'
+        },
+        minRolls: 1,
+        maxRolls: 1
+    })
+
     //Misc crops
     function miscCrop(mod, name, seed) {
         e.recipes.botanypots.crop({


### PR DESCRIPTION
When playing the modpack I noticed the Biomes You'll Go trees didn't have recipes with Botany Pots, this should add them. The drop table is very similar to other Botany Pots trees recipes, apart from the Orchard tree which has a higher chance of dropping apples. 

I also slightly changed some of the helper functions for growing trees, allowing for more extra drops (some of the trees dropped a vanilla Minecraft log, as well as a fruit). Could argue that `growTreeExtraBoP` is now misleadingly named since it is used for more than just BoP, but did not want to change too much.