### PR TITLE
Change dynview-common.toml settings.

### DIFF
--- a/config/dynview-common.toml
+++ b/config/dynview-common.toml
@@ -2,16 +2,16 @@
 ["Dynamic chunk view distance settings"]
 	#The maximum chunk view distance allowed to use, set to the max which a player could benefit from. default: 20
 	#Range: 1 ~ 200
-	maxChunkViewDist = 20
+	maxChunkViewDist = 12
 	#The average tick time to stabilize the chunk view distance around, setting it higher than 50ms is not advised, as after 50ms the tps will go below 20. default:40ms
 	#Range: 10 ~ 100
-	meanAvgTickTime = 45
+	meanAvgTickTime = 40
 	#The minimum chunk view distance allowed to use, set to what players should get at least. default: 4
 	#Range: 3 ~ 200
-	minChunkViewDist = 5
+	minChunkViewDist = 4
 	#Whether to output log messages for actions done, its helpful to balance the other settings nicely.
 	logMessages = true
 	#The update frequency of average server tick time checks to update view distances, default is every 30 seconds
 	#Range: 1 ~ 1000
-	viewDistanceUpdateRate = 30
+	viewDistanceUpdateRate = 60
 


### PR DESCRIPTION
The default settings used in dynview-common.toml can actually cause more lag, rather than helping. My proposed changes will reduce the max view distance to 12, which is higher than the game default of 10. It also reduces the min view distance to 4, which is the lowest acceptable view distance for most people. The average tick time to balance around is lower, which gives the game some more "overhead" in remaining cpu time per tick in case something causes a lag spike that should prevent it from dropping the view distance. Lastly, the update frequency has been doubled to once more minute to prevent changing too often, which should hopefully smooth out the experience.