### PR TITLE
Properly disable Salvager

### DIFF
--- a/kubejs/client_scripts/jei.js
+++ b/kubejs/client_scripts/jei.js
@@ -6,6 +6,7 @@ events.listen('jei.information', function (e) {
     info('allthemodium:allthemodium_ore', ['Check all the oceans for Allthemodium.', '(Y 5-45)'])
     info('allthemodium:vibranium_ore', ['Vibranium can be found in warped forests in the Nether.', '(Y 80-127)'])
     info('allthemodium:unobtainium_ore', ['Unobtainium can be obtained from the Highland biomes in the End.'])
+    info('silentgear:salvager', ['Disabled due to issue #349.'])
 })
 events.listen('jei.add.items', function (e) {
     e.add([

--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -56,7 +56,10 @@ events.listen('recipes', function (e) {
 
       'titanium:iron_gear',
       'titanium:gold_gear',
-      'titanium:diamond_gear'
+      'titanium:diamond_gear',
+
+      // issue #349
+      'silentgear:salvager'
     ]
   })
   e.remove({


### PR DESCRIPTION
As per issue #349, the Salvager was effectively disabled by making it return no items. This lead to a lot of players wasting all of their armor before realizing it doesn't work. This PR reverts that behavior and disables crafting instead, adding a helpful note in JEI.