### PR TITLE
Create cofh_core-client.toml

### DIFF
--- a/config/cofh_core-client.toml
+++ b/config/cofh_core-client.toml
@@ -1,0 +1,11 @@
+
+[Tooltips]
+	#If TRUE, Item descriptions will be added to their tooltips if possible.
+	"Show Item Descriptions" = true
+	#If TRUE, Enchantment descriptions will be added to the tooltip for Enchanted Books containing only a single enchantment.
+	"Show Enchantment Descriptions" = true
+
+[Render]
+	#If TRUE, Area Effect Block breaking will be rendered. Disable if you are using buggy mods such as OptiFine which apparently with this. Please also report the issue to OptiFine.
+	"Render Area Effect Block Breaking" = false
+


### PR DESCRIPTION
disable area effect block breaking render (resolves a bug in optifine where the screen will go white)