### PR TITLE
Update deadly.cfg

### DIFF
--- a/config/apotheosis/deadly.cfg
+++ b/config/apotheosis/deadly.cfg
@@ -21,11 +21,6 @@ bosses {
 
     # The possible mob types for bosses.  Format is weight@entity, entity is a registry name. [default: [3@minecraft:zombie], [3@minecraft:skeleton], [2@minecraft:husk], [2@minecraft:stray], [1@minecraft:wither_skeleton], [1@minecraft:pillager]]
     S:"Boss Spawner Mobs" <
-        3@iceandfire:hydra
-        3@iceandfire:cyclops
-        3@iceandfire:fire_dragon
-        3@iceandfire:ice_dragon
-        3@iceandfire:lightning_dragon
         3@minecraft:wither_skeleton
         3@minecraft:zombie
         3@minecraft:skeleton


### PR DESCRIPTION
remove dragons and other ice and fire mobs from apotheosis configs as apotheosis does not change existing mobs, it spawns them in if it cannot find them