### PR TITLE
Remove settings for release

### DIFF
--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -1,7 +1,3 @@
-settings.logAddedRecipes = true
-settings.logRemovedRecipes = true
-
-
 events.listen('recipes', function(e) {
     var mekCrush = e.recipes.mekanism.crushing
     var mekEnrich = e.recipes.mekanism.enriching


### PR DESCRIPTION
extra logging in the release build generates more questions than it solves. If a user is able to understand them, they could always turn them on themselves. Since it's our release build, if we're debugging, we could also turn them on ourselves.