### PR TITLE
Fixed typo on line 145

### DIFF
--- a/kubejs/server_scripts/unify.js
+++ b/kubejs/server_scripts/unify.js
@@ -142,7 +142,7 @@ onEvent('recipes', e => {
             energy: 3000
         });
 
-        if (!ingredient.of(`#forge:ores/${name}`).stack.empty) {
+        if (!ingredient.of(`#forge:ores/${name}`).stacks.empty) {
             e.recipes.minecraft.smelting(ingotItem, `#forge:ores/${name}`).xp(1);
             e.recipes.minecraft.blasting(ingotItem, `#forge:ores/${name}`).xp(1);
             e.recipes.mekanism.enriching(item.of(dustItem, 2), `#forge:ores/${name}`);


### PR DESCRIPTION
Typo was preventing proper execution of script. Can be tested by confirming this error no longer shows up.

Error occurred while handling event 'recipes': TypeError: Cannot read property "empty" from undefined (server_scripts:unify.js#145)