### PR TITLE
ReplaceInputs in Unify

### DIFF
--- a/kubejs/server_scripts/unify.js
+++ b/kubejs/server_scripts/unify.js
@@ -210,11 +210,11 @@ onEvent('recipes', e => {
                 },
                 turns: 8
             });
-        } //End of if (!ingredient.of(`#forge:ores/${name}`).empty)
-        //e.replaceInput(nuggetItem, (`#forge:nuggets/${name}`));
-        //e.replaceInput(dustItem, (`#forge:dusts/${name}`));
-        //e.replaceInput(ingotItem, (`#forge:ingots/${name}`));
-        //e.replaceInput(blockItem, (`#forge:storage_blocks/${name}`));
+        }
+        e.replaceInput(nuggetItem, (`#forge:nuggets/${name}`));
+        e.replaceInput(dustItem, (`#forge:dusts/${name}`));
+        e.replaceInput(ingotItem, (`#forge:ingots/${name}`));
+        e.replaceInput(blockItem, (`#forge:storage_blocks/${name}`));
     }
 
     function unifyCraftMetal(name, ingotItem, dustItem, blockItem, nuggetItem) {


### PR DESCRIPTION
Replaces input items with our unified input items in recipes.


This needs significant testing to confirm it worked well. Ore processing, alloys, crafting recipes. Should sample some of all of these.