### PR TITLE
Issue fixes

### DIFF
--- a/config/quark-common.toml
+++ b/config/quark-common.toml
@@ -435,7 +435,7 @@
 		#Can torches can be used as fuel in furnaces?
 		"Torches Burn" = true
 		#Can bones be smelted down to bone meal?
-		"Bone Meal Utility" = true
+		"Bone Meal Utility" = false
 
 	[tweaks.skull_pikes]
 		"Pike Range" = 5.0

--- a/kubejs/server_scripts/botany_pots.js
+++ b/kubejs/server_scripts/botany_pots.js
@@ -487,7 +487,8 @@ onEvent('recipes', e => {
     //Tier 6 Crops
     t6([
         'dragon_egg',
-        'nether_star'
+        'nether_star',
+        'nitro_crystal',
     ])
 
     //Magical Crops

--- a/kubejs/server_scripts/cloche.js
+++ b/kubejs/server_scripts/cloche.js
@@ -307,6 +307,7 @@ events.listen('recipes', function (e) {
   //Tier 6 Crops
   t6('dragon_egg')
   t6('nether_star')
+  t6('nitro_crystal')
 
   //Botanical Tier
   //t3('manasteel')

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -133,6 +133,7 @@ onEvent('item.tags', e => {
     e.remove('appliedenergistics2:wool', '#minecraft:wool');
     e.remove('appliedenergistics2:workbench', 'minecraft:crafting_table');
     e.remove('minecraft:beehives', ['resourcefulbees:t1_beehive', 'resourcefulbees:t2_beehive', 'resourcefulbees:t3_beehive', 'resourcefulbees:t4_beehive']);
+    e.remove('forge:cheese/silkentofu', 'pamhc2foodextended:silkentofuitem');
 
     e.add('minecraft:wart_blocks', '/.+_wart_block/');
     e.add('forge:axes', ['/.+_axe/', '/.+_paxel/', '/.+:axe_.+/']);


### PR DESCRIPTION
Disabled Quark recipe for smelting bone to bonemeal, which conflicts with Eidolon.

Removed cheese tag from tofu, because it was being unified to Rats cheese.

Add support for Nitro Crystal Seeds in botany pots and cloches.

All three changes have been tested in single player.