### PR TITLE
Fix Diamond bee model and add Glassential glasses as apiary blocks

### DIFF
--- a/config/resourcefulbees/bees/bees_gem/bred/Diamond.json
+++ b/config/resourcefulbees/bees/bees_gem/bred/Diamond.json
@@ -5,7 +5,8 @@
   "baseLayerTexture": "ores/diamond/diamond_bee",
   "ColorData": {
       "isBeeColored": false,
-      "honeycombColor": "#00ffff"
+      "honeycombColor": "#00ffff",
+      "modelType": "ORE"
   },
   "MutationData": {
       "hasMutation": false

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -225,6 +225,8 @@ onEvent('block.tags', e => {
     e.add('resourcefulbees:valid_apiary', [/^astralsorcery:marble_/, /^astralsorcery:black_marble_/, /^astralsorcery:infused_wood_/]);
     //Forbidden & Arcanus
     e.add('resourcefulbees:valid_apiary', /^forbidden_arcanus:[\w]*darkstone/);
+    //Glassential
+    e.add('resourcefulbees:valid_apiary', /^glassential:glass_/);
     //Create
     e.add('resourcefulbees:valid_apiary', [
         /^create:[\w]+_window/,


### PR DESCRIPTION
* Fixes the diamond bee so that it uses the ore model (@Pdiddy973 meant to do this but missed it in his last PR)
![image](https://user-images.githubusercontent.com/4309817/104795665-bf777800-5775-11eb-9d1a-1b48838356fc.png)

* Adds all Glassential glass blocks as valid apiary materials. Some of them don't make much actual sense to use (such as the ethereal glass that's only solid to players) but I'd rather let them all be used in-case there's some oddball usecase that I can't imagine (I mean it's not any worse than building an apiary entirely out of open doors which is already allowed).