### PR TITLE
recipe duplicates/additions

### DIFF
--- a/config/quark-common.toml
+++ b/config/quark-common.toml
@@ -121,7 +121,7 @@
 	"Tie Leads To Fences" = true
 	Turf = true
 	"Variant Bookshelves" = true
-	"Variant Chests" = true
+	"Variant Chests" = false
 	"Variant Ladders" = true
 	"Vertical Planks" = true
 	"Vertical Slabs" = true

--- a/kubejs/server_scripts/ct_recipes.js
+++ b/kubejs/server_scripts/ct_recipes.js
@@ -415,14 +415,28 @@ events.listen('recipes', function (e) {
     })
     //Quark
     e.shapeless('minecraft:chest', '#forge:chests/wooden')
-    e.shapeless('quark:oak_chest', ['minecraft:oak_planks', '#forge:chests/wooden'])
-    e.shapeless('quark:dark_oak_chest', ['minecraft:dark_oak_planks', '#forge:chests/wooden'])
-    e.shapeless('quark:acacia_chest', ['minecraft:acacia_planks', '#forge:chests/wooden'])
-    e.shapeless('quark:spruce_chest', ['minecraft:spruce_planks', '#forge:chests/wooden'])
-    e.shapeless('quark:birch_chest', ['minecraft:birch_planks', '#forge:chests/wooden'])
-    e.shapeless('quark:jungle_chest', ['minecraft:jungle_planks', '#forge:chests/wooden'])
-    e.shapeless('quark:warped_chest', ['minecraft:warped_planks', '#forge:chests/wooden'])
-    e.shapeless('quark:crimson_chest', ['minecraft:crimson_planks', '#forge:chests/wooden'])
+    e.shapeless('minecraft:trapped_chest', '#forge:chests/trapped')
+
+    const quarkWoodTypes = ['oak', 'dark_oak', 'acacia', 'spruce', 'birch', 'jungle', 'warped', 'crimson'];
+    quarkWoodTypes.forEach(wood => {
+        e.shapeless('quark:' + wood + '_chest', ['minecraft:' + wood + '_planks', '#forge:chests/wooden']);
+        e.shapeless('quark:' + wood + '_trapped_chest', ['quark:' + wood + '_chest', 'minecraft:tripwire_hook']);
+    });
+
+    function buildQuarkChest(type, material) {
+        e.shaped('quark:' + type + '_chest', [
+            'aaa',
+            'a a',
+            'aaa'
+        ], {a: material});
+        e.shapeless('quark:' + type + '_trapped_chest', ['quark:' + type + '_chest', 'minecraft:tripwire_hook']);
+    }
+
+    buildQuarkChest('nether_brick', 'minecraft:nether_bricks');
+    buildQuarkChest('prismarine', 'minecraft:prismarine');
+    buildQuarkChest('mushroom', '#forge:mushroom_caps');
+    buildQuarkChest('purpur', 'minecraft:purpur_block');
+
     //BluePower
     //e.shapeless(item.of('bluepower:blue_alloy_ingot', 4), ['#forge:dusts/teslatite','#forge:dusts/teslatite','#forge:dusts/teslatite','#forge:ingots/silver'])
     //RFTools

--- a/kubejs/server_scripts/ct_recipes.js
+++ b/kubejs/server_scripts/ct_recipes.js
@@ -2,14 +2,6 @@ events.listen('recipes', function (e) {
     //Removals
     e.remove({
         output: [
-            'quark:oak_chest',
-            'quark:dark_oak_chest',
-            'quark:acacia_chest',
-            'quark:spruce_chest',
-            'quark:birch_chest',
-            'quark:jungle_chest',
-            'quark:warped_chest',
-            'quark:crimson_chest',
             'quarryplus:solidquarry',
             'quarryplus:workbenchplus',
             'mininggadgets:upgrade_empty',

--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -102,6 +102,22 @@ events.listen('recipes', function(e) {
         G: '#forge:storage_blocks/gold',
         V: 'minecraft:villager_spawn_egg'
     })
+    e.shaped(item.of('enviromats:alabaster_magenta', 8), [
+        'AAA',
+        'AMA',
+        'AAA'
+    ], {
+        A: '#forge:alabaster',
+        M: '#forge:dyes/magenta'
+    })
+    e.shaped(item.of('minecraft:ladder', 4), [
+        'S S',
+        'SPS',
+        'S S'
+    ], {
+        S: '#forge:rods',
+        P: '#minecraft:planks'
+    })
     e.smelting(item.of('appliedenergistics2:certus_quartz_crystal'), '#forge:ores/certus_quartz').xp(1)
     e.smelting(item.of('minecraft:glass'), '#forge:sand').xp(.1)
     e.shapeless(item.of('minecraft:clay_ball', 4), 'minecraft:clay')

--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -168,13 +168,6 @@ events.listen('recipes', function(e) {
         'C': 'resourcefulbees:lava_honeycomb',
         'B': 'minecraft:bucket'
     })
-    kjsShaped('minecraft:chest', [
-        'LLL',
-        'L L',
-        'LLL'
-    ], {
-        'L': '#minecraft:logs'
-    }, 4)
     kjsShaped('appliedenergistics2:sky_stone_block', [
         'BSB',
         'SBS',


### PR DESCRIPTION
Tested in single player. 

Quark makes numerous changes to chest recipes, disabling the variant chests feature removes those.

This fixes the vanilla chest and trapped chest recipes.

This also lets us clean up our removal script, though we do then have to add new recipes for the non-wood quark chests.

Quark provides a recipe for logs to chests, so we don't need the KubeJS one.