### PR TITLE
set invtweaks default to inventory only

### DIFF
--- a/config/invtweaks-client.toml
+++ b/config/invtweaks-client.toml
@@ -1,0 +1,3 @@
+[tweaks]
+enableSort=1
+enableButtons=1


### PR DESCRIPTION
This should fix most of the dupe bugs with Inventory Tweaks, by setting it to only sort player inventory.

Tested that the rest of the configuration is generated automatically.