### PR TITLE
disable custom image uploads for camera mod

### DIFF
--- a/defaultconfigs/camera-server.toml
+++ b/defaultconfigs/camera-server.toml
@@ -1,0 +1,2 @@
+[image]
+allow_upload = false


### PR DESCRIPTION
removing the mod would be better, but this partially avoids the security issues for worlds going forward if we'd rather keep it.