### PR TITLE
removes mob swab

### DIFF
--- a/kubejs/client_scripts/client_scripts.js
+++ b/kubejs/client_scripts/client_scripts.js
@@ -119,7 +119,10 @@ onEvent(`jei.hide.items`, e => {
         `eidolon:lead_nugget`,
 
         /resourcefulbees:.+_bee_spawn_egg/,
-        `twilightforest:uncrafting_table`
+        `twilightforest:uncrafting_table`,
+        `mob_grinding_utils:mob_swab`,
+        `mob_grinding_utils:mob_swab_used`,
+        `mob_grinding_utils:gm_chicken_feed`
     ]);
 
     colors.forEach(color => {

--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -145,7 +145,8 @@ events.listen('recipes', e => {
         'mysticalagriculture:unattuned_augment',
         'rftoolsbuilder:builder',
         'extrastorage:iron_crafter',
-        'twilightforest:uncrafting_table'
+        'twilightforest:uncrafting_table',
+        'mob_grinding_utils:recipe_mob_swab'
 
     ];
     idRemove.forEach(iR => {


### PR DESCRIPTION
removes mob swab since it can be used to dupe mobs, including bees/dragons, no blacklist or cfg available to disable specific mobs