### PR TITLE
Update randompatches.toml to reflect current mod

### DIFF
--- a/config/randompatches.toml
+++ b/config/randompatches.toml
@@ -1,63 +1,104 @@
 # RandomPatches configuration
+# All configuration options not under [client] are server-sided unless otherwise stated.
 
-# Options related to the movement speed limits.
-[speedLimits]
+# Options related to player speed limits.
+# These options are used to fix MC-90062: https://bugs.mojang.com/browse/MC-90062
+[player_speed_limits]
 	# The maximum player elytra speed.
 	# The vanilla default is 300.0.
-	# Min: 1.0
-	# Max: 3.4028234663852886E38
+	# Min: 0.0
+	# Max: 3.4028235E38
 	# Default: 1000000.0
-	maxPlayerElytraSpeed = 1000000.0
+	max_elytra_speed = 1000000.0
 	# The maximum player vehicle speed.
 	# The vanilla default is 100.0.
-	# Min: 1.0
+	# Min: 0.0
 	# Max: 1.7976931348623157E308
 	# Default: 1000000.0
-	maxPlayerVehicleSpeed = 1000000.0
-	# The maximum player speed.
+	max_vehicle_speed = 1000000.0
+	# The maximum player speed when not riding a vehicle or flying with elytra.
 	# The vanilla default is 100.0.
-	# Min: 1.0
-	# Max: 3.4028234663852886E38
+	# Min: 0.0
+	# Max: 3.4028235E38
 	# Default: 1000000.0
-	maxPlayerSpeed = 1000000.0
+	default_max_speed = 1000000.0
 
-# Options related to the disconnect timeouts.
-[timeouts]
-	# The interval at which the server sends the KeepAlive packet.
+# Options related to connection timeouts.
+[connection_timeouts]
+	# The interval in seconds at which KeepAlive packets are sent to clients.
 	# Min: 1
 	# Max: 2147483647
 	# Default: 15
-	keepAlivePacketInterval = 15
-	# The read timeout in seconds.
-	# This is the time it takes for a player to be disconnected after not responding to a KeepAlive packet.
-	# This value is automatically rounded up to a product of keepAlivePacketInterval.
+	keep_alive_packet_interval_seconds = 15
+	# The connection read timeout in seconds.
+	# This value is used on both the client and the server.
 	# Min: 1
 	# Max: 2147483647
-	# Default: 90
-	readTimeout = 90
+	# Default: 120
+	read_timeout_seconds = 120
 	# The login timeout in ticks.
 	# Min: 1
 	# Max: 2147483647
-	# Default: 900
-	loginTimeout = 12000
+	# Default: 2400
+	login_timeout_ticks = 12000
+	# The KeepAlive timeout in seconds.
+	# This is how long the server waits for a player to return a KeepAlive packet before disconnecting them.
+	# This is automatically rounded up to a multiple of the KeepAlive packet interval.
+	# Min: 1
+	# Max: 2147483647
+	# Default: 120
+	keep_alive_timeout_seconds = 180
+	
+# Options related to packet size limits.
+[packet_size_limits]
+	# The maximum compressed packet size.
+	# The vanilla limit is 2097152.
+	# This option is both client and server-sided.
+	# Setting this to a higher value than the vanilla limit can fix MC-185901, which may cause players to be disconnected: https://bugs.mojang.com/browse/MC-185901
+	# Min: 256
+	# Max: 2147483647
+	# Default: 16777216
+	max_compressed_packet_size = 16777216
+	# The maximum NBT compound tag packet size.
+	# The vanilla limit is 2097152.
+	# This option is both client and server-sided.
+	# Setting this to a higher value than the vanilla limit may prevent players from being disconnected.
+	# Min: 256
+	# Max: 2147483647
+	# Default: 16777216
+	max_nbt_compound_tag_packet_size = 16777216
+	# The maximum client custom payload packet size.
+	# The vanilla limit is 32767.
+	# Setting this to a higher value than the vanilla limit may prevent the client from being disconnected.
+	# Min: 256
+	# Max: 2147483647
+	# Default: 16777216
+	max_client_custom_payload_packet_size = 16777216
 
-# Options related to client-sided features.
+# Client-sided options.
 [client]
-	# Forces Minecraft to show the title screen after disconnecting rather than the Multiplayer or Realms menu.
+	# Causes Minecraft to show the main menu screen after disconnecting rather than the Realms or multiplayer screen.
 	# Default: false
-	forceTitleScreenOnDisconnect = false
-	# Whether to remove the glowing effect from potions.
+	return_to_main_menu_after_disconnect = false
+	# Removes the glowing effect from potions.
+	# This makes the potion colors more visible.
+	# Default: true
+	remove_glowing_effect_from_potions = true
+	# Removes the glowing effect from enchanted books.
 	# Default: false
-	removePotionGlint = false
+	remove_glowing_effect_from_enchanted_books = false
 	# The framerate limit slider step size.
-	# If this is set to 10.0, vanilla behavior is not changed.
-	# Min: 4.9E-324
+	# The vanilla default is 10.0.
+	# Min: 1.4E-45
 	# Max: 260.0
 	# Default: 1.0
-	framerateLimitSliderStepSize = 1.0
+	framerate_limit_slider_step_size = 1.0
 
 	# Options related to the Minecraft window.
 	[client.window]
+		# Enables custom Minecraft window titles.
+		# Default: true
+		custom_title = true
 		# The path to the 256x256 window icon which is used on Mac OS X.
 		# Leave this, the 16x16 icon and the 32x32 icon blank to use the default icon.
 		# Default: 
@@ -70,43 +111,67 @@
 		# Leave this and the 16x16 icon blank to use the default icon.
 		# Default: 
 		icon32 = ""
+		# The simple Minecraft window title.
+		# The current activity, the number of mods loaded and mod versions are not available.
+		# Variables:
+		#  - ${mcversion}: The Minecraft version
+		#  - ${username}: The username.
+		# '$' can be escaped by using an extra '$'.
+		# Default: "Minecraft ${mcversion}"
+		simple_title = "Minecraft ${mcversion} - ATM-6"
 		# The Minecraft window title.
-		# The Minecraft version is provided as an argument.
-		# Default: Minecraft* %s
-		title = "Minecraft ${mcversion} - ATM6"
-		# The Minecraft window title.
-		# The Minecraft version and current activity are provided as arguments.
-		# For example: "RandomPatches - %2$s"
-		# Default: Minecraft* %s - %s
-		titleWithActivity = "Minecraft ${mcversion} - ATM6 - ${activity}"
+		# The current activity is not available.
+		# Variables:
+		#  - ${mcversion}: The Minecraft version
+		#  - ${username}: The username.
+		#  - ${modsloaded}: The number of mods loaded.
+		#  - ${modversion:modid}: The version of the mod with the specified ID.
+		# '$' can be escaped by using an extra '$'.
+		# Default: "Minecraft ${mcversion}"
+		title = "Minecraft ${mcversion} - ATM-6"
+		# The Minecraft window title that also takes into account the current activity.
+		# Variables:
+		#  - ${mcversion}: The Minecraft version
+		#  - ${activity}: The current activity.
+		#  - ${username}: The username.
+		#  - ${modsloaded}: The number of mods loaded.
+		#  - ${modversion:modid}: The version of the mod with the specified ID.
+		# '$' can be escaped by using an extra '$'.
+		# Default: "Minecraft ${mcversion} - ${activity}"
+		title_with_activity = "Minecraft ${mcversion} - ATM-6 - ${activity}"
 
-# Options related to boats.
-[boats]
-	# Prevents underwater boat passengers from being ejected after 60 ticks (3 seconds).
-	# Default: false
-	preventUnderwaterBoatPassengerEjection = false
+# Miscellaneous options.
+[misc]
 	# The buoyancy of boats when they are under flowing water.
 	# The vanilla default is -0.0007.
-	# Min: -1.7976931348623157E308
-	# Max: 1.7976931348623157E308
+	# Setting this to a positive value allows boats to float up when they move into a higher block of water, fixing MC-91206: https://bugs.mojang.com/browse/MC-91206
 	# Default: 0.023
-	underwaterBoatBuoyancy = 0.023
-
-# Options that don't fit into any other categories.
-[misc]
-	# The packet size limit.
-	# The vanilla limit is 2097152.
-	# Min: 257
+	boat_buoyancy_under_flowing_water = 0.023
+	# How long it takes in ticks for a boat passenger to be ejected when underwater.
+	# Set this to -1 to disable underwater boat passenger ejection.
+	# Min: -1
 	# Max: 2147483647
-	# Default: 16777216
-	packetSizeLimit = 16777216
-	# Enables the portal bucket replacement fix for Nether portals.
-	# Default: false
-	portalBucketReplacementFixForNetherPortals = false
-	# Whether skull stacking requires the same textures or just the same player profile.
-	# Default: true
-	skullStackingRequiresSameTextures = true
-	# Enables the /rpreload command.
-	# Default: true
-	rpreload = true
+	# Default: 60
+	underwater_boat_passenger_ejection_delay_ticks = 60
+	# The name of the command that reloads this configuration from disk.
+	# Set this to an empty string to disable the command.
+	# Changes to this option are applied when a server is loaded.
+	# Default: "rpconfigreload"
+	config_reload_command = "rpconfigreload"
 
+	# Miscellaneous bug fixes.
+	[misc.bug_fixes]
+		# Fixes player heads from the same player sometimes not stacking.
+		# DISABLED: Disables this fix.
+		# REQUIRE_SAME_PLAYER_AND_TEXTURE_URL: Player heads can stack if they are from the same player and have the same texture URL.
+		# REQUIRE_SAME_PLAYER: Player heads can stack if they are from the same player.
+		# This bug is reported as MC-100044: https://bugs.mojang.com/browse/MC-100044
+		# Default: "REQUIRE_SAME_PLAYER_AND_TEXTURE_URL"
+		fix_player_head_stacking = "REQUIRE_SAME_PLAYER_AND_TEXTURE_URL"
+		# Fixes duplicate entity UUIDs by assigning new UUIDs to the affected entities.
+		# This bug is reported as MC-95649: https://bugs.mojang.com/browse/MC-95649
+		# Default: true
+		fix_duplicate_entity_uuids = true
+		# Logs fixed entity UUIDs.
+		# Default: true
+		log_fixed_duplicate_entity_uuids = false


### PR DESCRIPTION
Updated key names to reflect current mod settings - they get ignored otherwise.
Updated `simple_title`, `title` and `title_with_activity` to include `ATM-6`
Added `keep_alive_timeout_seconds` and increased to `180` - may reduce number of people getting server forcibly closed error
Added packet size limits, but left at default.
Removed boat section and moved to misc
Updated comments