### PR TITLE
Add CM walls to dragon blacklist and no_moving tag

### DIFF
--- a/config/iceandfire-common.toml
+++ b/config/iceandfire-common.toml
@@ -117,7 +117,7 @@
 
 	[Dragons.Griefing]
 		#Blocks that a dragon cannot break. Use the format like "minecraft:chest" or "rats:block_of_cheese" 
-		blacklistedBreakBlocks = ["minecraft:obsidian", "minecraft:bedrock", "minecraft:ancient_debris", "minecraft:barrier", "cyclic:unbreakable_block", "cyclic:unbreakable_reactive", "metalbarrels:obsidian_barrel", "ironfurnaces:million_furnace", "powah:energy_cell_creative", "mekanism:creative_energy_cube", "ctiers:centrifuge_controller_tier_creative", "ctiers:centrifuge_casing_tier_creative", "refinedstorage:creative_controller", "creativewirelesstransmitter:creative_wireless_transmitter", "creativecrafter:creative_crafter", "creativeapiary:tcreative_apiary"]
+		blacklistedBreakBlocks = ["minecraft:obsidian", "minecraft:bedrock", "minecraft:ancient_debris", "minecraft:barrier", "cyclic:unbreakable_block", "cyclic:unbreakable_reactive", "metalbarrels:obsidian_barrel", "ironfurnaces:million_furnace", "powah:energy_cell_creative", "mekanism:creative_energy_cube", "ctiers:centrifuge_controller_tier_creative", "ctiers:centrifuge_casing_tier_creative", "refinedstorage:creative_controller", "creativewirelesstransmitter:creative_wireless_transmitter", "creativecrafter:creative_crafter", "creativeapiary:tcreative_apiary", "compactmachines:solid_wall"]
 		#Dragon griefing - 2 is no griefing, 1 is breaking weak blocks, 0 is default
 		#Range: 0 ~ 2
 		"Dragon Griefing" = 1

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -245,9 +245,21 @@ onEvent('block.tags', e => {
         '#forge:ores/dimensionalshard',
         '#forge:ores/arcane_brick'
     ])
-    e.add('misctags:no_moving', ['#minecraft:wither_immune', 'potionsmaster:cauldron', 'appliedenergistics2:cable_bus'])
+    e.add('misctags:no_moving', [
+        '#minecraft:wither_immune',
+        'potionsmaster:cauldron',
+        'appliedenergistics2:cable_bus',
+        'cookingforblockheads:fridge',
+        /^refinedstorage:/,
+        /^extrastorage:/,
+        /^waystones:/,
+        /^compactmachines:/,
+        /^appliedenergistics2:/,
+    ])
     e.add('mekanism:cardboard_blacklist', '#misctags:no_moving')
     e.add('bagofyurting:blacklist', '#misctags:no_moving')
+    e.add('create:brittle', '#misctags:no_moving')
+
     e.add('misctags:flowers/draconic_flowers', ['minecraft:dragon_egg'])
     e.add('misctags:flowers/end_flowers', ['minecraft:chorus_flower', 'minecraft:chorus_plant'])
     e.add('misctags:flowers/forest_flowers', ['#minecraft:flowers', 'minecraft:sweet_berry_bush'])
@@ -325,13 +337,7 @@ onEvent('block.tags', e => {
     e.add('cyclic:scythe_brush', ['#minecraft:flowers'])
     e.add('mcwwindows:window', '/mcwwindows:.+_win/')
     e.add('misctags:concrete', '/minecraft:.+_concrete/')
-    e.add('misctags:no_moving', [
-        '/refinedstorage:.+/',
-        '/extrastorage:.+/',
-        '/waystones:.+/',
-        '/appliedenergistics2:.+/'
-    ])
-    e.add('create:brittle', 'cookingforblockheads:fridge')
+
     e.removeAll('minecraft:enderman_holdable')
 })
 


### PR DESCRIPTION
Should prevent compact machine escape through dragons, Bag of Yurting, or Create. Also adds the `create:brittle` tag to everything in the `no_moving` tag.