### PR TITLE
Fix traits on bees to prevent log warnings

### DIFF
--- a/config/resourcefulbees/bees/bred/bees_gem/Certus.json
+++ b/config/resourcefulbees/bees/bred/bees_gem/Certus.json
@@ -1,7 +1,7 @@
 {
     "flower": "appliedenergistics2:quartz_block",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/certus_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_gem/Diamond.json
+++ b/config/resourcefulbees/bees/bred/bees_gem/Diamond.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/diamond",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ores/diamond/diamond_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_gem/Emerald.json
+++ b/config/resourcefulbees/bees/bred/bees_gem/Emerald.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/emerald",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ores/emerald/emerald_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_gem/Fluorite.json
+++ b/config/resourcefulbees/bees/bred/bees_gem/Fluorite.json
@@ -1,7 +1,7 @@
 {
     "flower": "mekanism:fluorite_ore",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/fluorite_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_gem/Lapis.json
+++ b/config/resourcefulbees/bees/bred/bees_gem/Lapis.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/lapis",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ores/lapis/lapis_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_gem/Redstone.json
+++ b/config/resourcefulbees/bees/bred/bees_gem/Redstone.json
@@ -1,7 +1,7 @@
 {
     "flower": "minecraft:redstone_block",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ores/redstone/redstone_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_ingot/Allthemodium.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Allthemodium.json
@@ -97,6 +97,6 @@
         "breedDelay": 6000
     },
     "TraitData": {
-        "hasTraits": false
+        "hasTraits": true
     }
 }

--- a/config/resourcefulbees/bees/bred/bees_ingot/Aluminum.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Aluminum.json
@@ -83,6 +83,6 @@
         "breedDelay": 6000
     },
     "TraitData": {
-        "hasTraits": false
+        "hasTraits": true
     }
 }

--- a/config/resourcefulbees/bees/bred/bees_ingot/Copper.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Copper.json
@@ -83,6 +83,6 @@
         "breedDelay": 6000
     },
     "TraitData": {
-        "hasTraits": false
+        "hasTraits": true
     }
 }

--- a/config/resourcefulbees/bees/bred/bees_ingot/Gold.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Gold.json
@@ -97,6 +97,6 @@
         "breedDelay": 6000
     },
     "TraitData": {
-        "hasTraits": false
+        "hasTraits": true
     }
 }

--- a/config/resourcefulbees/bees/bred/bees_ingot/Iron.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Iron.json
@@ -83,6 +83,6 @@
         "breedDelay": 6000
     },
     "TraitData": {
-        "hasTraits": false
+        "hasTraits": true
     }
 }

--- a/config/resourcefulbees/bees/bred/bees_ingot/Lead.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Lead.json
@@ -83,6 +83,6 @@
         "breedDelay": 6000
     },
     "TraitData": {
-        "hasTraits": false
+        "hasTraits": true
     }
 }

--- a/config/resourcefulbees/bees/bred/bees_ingot/Nickel.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Nickel.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/nickel",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ato/nickel_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_ingot/Osmium.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Osmium.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/osmium",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ato/osmium_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_ingot/Platinum.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Platinum.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/platinum",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ato/platinum_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_ingot/Silver.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Silver.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/silver",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ato/silver_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_ingot/Tin.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Tin.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/tin",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ato/tin_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_ingot/Uraninite.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Uraninite.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/uraninite",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ato/uraninite_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_ingot/Uranium.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Uranium.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/uranium",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ato/uranium_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_ingot/Zinc.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Zinc.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/zinc",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ato/zinc_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_misc/Coal.json
+++ b/config/resourcefulbees/bees/bred/bees_misc/Coal.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/coal",
     "maxTimeInHive": 2400,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "ores/coal/coal_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_misc/Obsidian.json
+++ b/config/resourcefulbees/bees/bred/bees_misc/Obsidian.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:obsidian",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_misc/Stoned.json
+++ b/config/resourcefulbees/bees/bred/bees_misc/Stoned.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:stone",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/stoned_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/bred/bees_mob/Dragonic.json
+++ b/config/resourcefulbees/bees/bred/bees_mob/Dragonic.json
@@ -1,7 +1,7 @@
 {
     "flower": "minecraft:end_stone",
     "maxTimeInHive": 4800,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_gem/Aquamarine.json
+++ b/config/resourcefulbees/bees/natural/bees_gem/Aquamarine.json
@@ -1,7 +1,7 @@
 {
     "flower": "astralsorcery:starmetal",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/aquamarine_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_ingot/Crimson_Iron.json
+++ b/config/resourcefulbees/bees/natural/bees_ingot/Crimson_Iron.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/crimson_iron",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/crimson_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Cobbee.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Cobbee.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:cobblestone",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/cobbee_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Cropy.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Cropy.json
@@ -1,7 +1,7 @@
 {
     "flower": "minecraft:hay_block",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/crop/wheat_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Dirty.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Dirty.json
@@ -1,7 +1,7 @@
 {
   "flower": "tag:forge:dirt",
   "maxTimeInHive": 1200,
-  "traits": [""],
+  "traits": [],
   "hasHoneycomb": true,
   "baseLayerTexture": "misc/dirty_bee",
   "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Gravely.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Gravely.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:gravel",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/gravely_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Icey.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Icey.json
@@ -1,7 +1,7 @@
 {
     "flower": "minecraft:blue_ice",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Leafy.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Leafy.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:minecraft:leaves",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Lumber.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Lumber.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:minecraft:logs",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Mana.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Mana.json
@@ -1,7 +1,7 @@
 {
     "flower": "botania:terrasteel_block",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Mason.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Mason.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:storage_blocks/clay",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Mystical.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Mystical.json
@@ -1,7 +1,7 @@
 {
     "flower": "botania:livingrock",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/RGBee.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/RGBee.json
@@ -1,7 +1,7 @@
 {
     "flower": "all",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/ores/custom/custom_bee_primary",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Salt_Baee.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Salt_Baee.json
@@ -1,7 +1,7 @@
 {
     "flower": "mekanism:block_salt",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/salt_baee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Sandy.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Sandy.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:sand",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/sandy_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_misc/Stan.json
+++ b/config/resourcefulbees/bees/natural/bees_misc/Stan.json
@@ -1,7 +1,7 @@
 {
     "flower": "tag:forge:stone",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "misc/stan_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_mob/KoBee_Beef.json
+++ b/config/resourcefulbees/bees/natural/bees_mob/KoBee_Beef.json
@@ -1,7 +1,7 @@
 {
     "flower": "cookingforblockheads:fridge",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/custom/bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_mob/Slimy.json
+++ b/config/resourcefulbees/bees/natural/bees_mob/Slimy.json
@@ -1,7 +1,7 @@
 {
     "flower": "minecraft:slime_block",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/slime/slime_bee",
     "ColorData": {

--- a/config/resourcefulbees/bees/natural/bees_mob/Spooky.json
+++ b/config/resourcefulbees/bees/natural/bees_mob/Spooky.json
@@ -1,7 +1,7 @@
 {
     "flower": "minecraft:bone_block",
     "maxTimeInHive": 1200,
-    "traits": [""],
+    "traits": [],
     "hasHoneycomb": true,
     "baseLayerTexture": "/skeleton/skeleton_bee",
     "ColorData": {


### PR DESCRIPTION
Fixes the following warnings:
```
[Worker-Main-10/WARN] [com.resourcefulbees.resourcefulbees.ResourcefulBees/]: Trait '' given to 'redstone' does not exist in trait registry.
...
[Worker-Main-10/WARN] [com.resourcefulbees.resourcefulbees.ResourcefulBees/]: Traits provided but TraitData object does not exist or does not contain "hasTraits: true" for 'allthemodium'
...
```