### PR TITLE
Disable Tombstone Soulbound enchantment

### DIFF
--- a/config/tombstone-server.toml
+++ b/config/tombstone-server.toml
@@ -1,0 +1,4 @@
+#Allows to customize or disable the enchantments
+[enchantments]
+	#Enables the enchantment Soulbound [false/true|default:true]
+	enable_enchantment_soulbound = false


### PR DESCRIPTION
Tombstone Soulbound currently applies to many things it should not, and breaks Pedestals enchantment books because of it. There is another Soulbound enchant from Ensorcellation, which works correctly, so this one can be disabled.

This does not remove the enchant from existing items, just removes it from the enchanting table.