### PR TITLE
halved the world loading time

### DIFF
--- a/config/jeresources-common.toml
+++ b/config/jeresources-common.toml
@@ -7,4 +7,4 @@ showDevData = false
 enchantsBlacklist = ["flimflam", "soulBound", "reactive"]
 hiddenTabs = []
 dimensionsBlacklist = [-11]
-
+disableLootManagerReloading = true

--- a/config/jeresources.toml
+++ b/config/jeresources.toml
@@ -7,4 +7,4 @@ showDevData = false
 enchantsBlacklist = ["flimflam", "soulBound", "reactive"]
 hiddenTabs = []
 dimensionsBlacklist = [-11]
-
+disableLootManagerReloading = true


### PR DESCRIPTION
Just Enough Resources calls reload again when joining the world to fetch loot manager data.
It basically reloads twice which is not necessary. This fix halves the world loading time and also gets rid of the "KubeJS reloaded without any errors" message which only appears because it reloads again.

Errors are still printed normally and when reloading manually, it will still display the message.

Minimum required version of Just Enough Resources for this to work is: 0.12.0.109