### PR TITLE
Disable Myrmex queen spawning in overworld

### DIFF
--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -58,5 +58,11 @@
       "mana-and-artifice"
     ],
     "result": "deny"
+  },
+  {
+    "dimension": "minecraft:overworld",
+    "mob": "iceandfire:myrmex_queen",
+    "result": "deny",
+    "onjoin": true
   }
 ]


### PR DESCRIPTION
When a Myrmex queen spawns without a pre-existing structure, they will create one, ignoring claims. This disables placing them in the overworld, which should prevent the majority of problems.