### PR TITLE
Add botany pot recipe for Twilight Forest dungeon saplings

### DIFF
--- a/kubejs/server_scripts/mod_specific/botany_pots/botany_pots.js
+++ b/kubejs/server_scripts/mod_specific/botany_pots/botany_pots.js
@@ -219,5 +219,24 @@ onEvent(`recipes`, e => {
       maxRolls: 2
     }
   ], `ars_nouveau:mana_bloom_crop`).categories([`dirt`])
+
+  // Twilight Forest Dungeon Saplings
+  // These only drop logs, not saplings
+  for (let tree of ["transformation", "sorting", "mining", "time"]) {
+    e.recipes.botanypots.crop({
+      seed: Item.of(`twilightforest:${tree}_sapling`).toJson(),
+      categories: ["dirt"],
+      growthTicks: 2400,
+      display: {
+        block: `twilightforest:${tree}_sapling`
+      },
+      results: [{
+        chance: 0.25,
+        output: Item.of(`twilightforest:${tree}_log`).toResultJson(),
+        minRolls: 1,
+        maxRolls: 1
+      }]
+    }).id(`kubejs:botany_pots/botanytrees/${tree}_tree`)
+  }
   //#endregion
 })


### PR DESCRIPTION
By default there is no way to get usable quantities of logs from these, since they don't drop more saplings when you plant them. 

This adds botany pot recipes for the dungeon trees, that only drop logs.