### PR TITLE
Add RFToolsDimensions Biomes (only the biomes) and also force some iceandfire structure spawns.

### DIFF
--- a/config/rftoolsdim/allthemodium.json
+++ b/config/rftoolsdim/allthemodium.json
@@ -1,0 +1,172 @@
+[
+	{
+		"type": "fluid",
+		"key": "allthemodium:molten_bluelava",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:the_other",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:nether_wastes",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:soul_sand_valley",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:badlands",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:mountain_edge",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:mountains",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:gravelly_mountains",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:modified_gravelly_mountains",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:desert",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:desert_hills",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:badlands_plateau",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:modified_badlands_plateau",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:eroded_badlands",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:crimson_forest",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:warped_forest",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	},
+	{
+		"type": "biome",
+		"key": "allthemodium:basalt_deltas",
+		"rarity": "rare",
+		"create": 100,
+		"maintain": 100,
+		"ticks": 100,
+		"worldgen": false,
+		"dimlet": true
+	}
+]

--- a/config/rftoolsdim/allthemodium.json
+++ b/config/rftoolsdim/allthemodium.json
@@ -1,15 +1,5 @@
 [
 	{
-		"type": "fluid",
-		"key": "allthemodium:molten_bluelava",
-		"rarity": "rare",
-		"create": 100,
-		"maintain": 100,
-		"ticks": 100,
-		"worldgen": false,
-		"dimlet": true
-	},
-	{
 		"type": "biome",
 		"key": "allthemodium:the_other",
 		"rarity": "rare",

--- a/defaultconfigs/rftoolsdim-server.toml
+++ b/defaultconfigs/rftoolsdim-server.toml
@@ -1,0 +1,108 @@
+
+#Dimension settings
+[dimensions]
+	#The maintenance cost of randomized dimlets is multiplied with this value before applying to the dimension
+	#Range: 0.0 ~ 10.0
+	randomizedDimletCostFactor = 0.1
+	#The chance of a dimlet hut for a given chunk
+	#Range: 0.0 ~ 1.0
+	dimletHutChance = 0.005
+	#At this maintenance cost thresshold and below the minimum dimension power (dimensionPowerMinimum is used
+	#Range: > 0
+	minPowerThresshold = 100
+	#At this maintenance cost thresshold and above the maximum dimension power (dimensionPowerMaximum is used
+	#Range: > 0
+	maxPowerThresshold = 5000
+	#Maximum power in a dimension. This is the minimum value used by dimensions that don't consume a lot of power
+	#Range: 0 ~ 9223372036854775807
+	dimensionPowerMinimum = 20000000
+	#Maximum power in a dimension. This is the maximum value used by dimensions that consume a lot of power
+	#Range: 0 ~ 9223372036854775807
+	dimensionPowerMaximum = 40000000
+	#Maximum power of a dimension is always a multiple of this value
+	#Range: 1 ~ 9223372036854775807
+	powerMultiples = 500000
+	#The zero power percentage at which power warning signs are starting to happen. This is only used for lighting level. No other debuffs occur at this level.
+	#Range: 0 ~ 100
+	dimensionPowerWarn0 = 12
+	#The first power percentage at which power warning signs are starting to happen
+	#Range: 0 ~ 100
+	dimensionPowerWarn1 = 9
+	#The second power percentage at which power warning signs are starting to become worse
+	#Range: 0 ~ 100
+	dimensionPowerWarn2 = 2
+	#The third power percentage at which power warning signs are starting to be very bad
+	#Range: 0 ~ 100
+	dimensionPowerWarn3 = 1
+	#Enable dynamic scaling of the Phase Field Generator cost based on world tick cost
+	enableDynamicPhaseCost = false
+	#How much of the tick cost of the world is applied to the PFG cost, as a ratio from 0 to 1
+	#Range: 0.0 ~ 1.0
+	dynamicPhaseCostAmount = 0.05000000074505806
+	#If true you will get some debufs when the PFG is in use. If false there will be no debufs
+	phasedFieldGeneratorDebuf = true
+	#If true creating dimensions requires an owner dimlet
+	ownerDimletRequired = false
+
+#Dimension Builder settings
+[dimensionbuilder]
+	#Maximum RF storage that the dimension builder can receive per side
+	#Range: > 0
+	generatorMaxRF = 20000
+	#Maximum RF storage that the phased field generator item can hold
+	#Range: 0 ~ 9223372036854775807
+	phasedFieldMaxRF = 1000000
+	#RF per tick that the phased field generator item can receive
+	#Range: 0 ~ 9223372036854775807
+	phasedFieldRFPerTick = 1000
+	#RF per tick that the phased field generator item will consume
+	#Range: 0 ~ 9223372036854775807
+	phasedFieldConsumePerTick = 100
+
+#Dimlets settings
+[dimlets]
+	#This is a list of dimlet packages that will be used. Later dimlet packages can override dimlets defined in earlier packages. You can place these packages in the 'config/rftoolsdim' folder
+	dimletPackages = ["base.json", "vanilla_blocks.json", "vanilla_fluids.json", "vanilla_biomes.json", "rftools.json", "appliedenergistics2.json", "biggerreactors.json", "bigreactors.json", "botania.json", "immersiveengineering.json", "mekanism.json", "powah.json", "quark.json", "tconstruct.json", "thermal.json", "biomesoplenty.json", "allthemodium.json"]
+
+#Dimlet Workbench settings
+[dimletworkbench]
+	#Maximum amount of power the researcher can store
+	#Range: > 0
+	researcherMaxPower = 100000
+	#Amount of RF per tick input (per side) for the researcher
+	#Range: > 0
+	researcherRFPerTick = 10000
+	#Amount of RF per tick the researcher uses while operating
+	#Range: > 0
+	researcherUsePerTick = 200
+	#How many ticks are needed to research one item
+	#Range: > 0
+	researcheTime = 400
+
+#Dimension Builder settings
+[blobs]
+	#Regeneration level of the common blob in case the dimension has power
+	#Range: > 0
+	commonBlobRegen = 2
+	#Regeneration level of the rare blob in case the dimension has power
+	#Range: > 0
+	rareBlobRegen = 3
+	#Regeneration level of the legendary blob in case the dimension has power
+	#Range: > 0
+	legendaryBlobRegen = 4
+	#Below this dimension power the regeneration of the blobs stop
+	#Range: 0 ~ 9223372036854775807
+	blobRegenerationLevel = 1000
+
+#Essence settings
+[essences]
+	#Amount of blocks needed for a single block dimlet (for the block absorber)
+	#Range: > 1
+	maxBlockAbsorption = 256
+	#Amount of fluid blocks needed for a single fluid dimlet (for the fluid absorber)
+	#Range: > 1
+	maxFluidAbsorption = 256
+	#Amount of ticks needed for a single biome dimlet (for the biome absorber)
+	#Range: > 1
+	maxBiomeAbsorption = 5000
+

--- a/kubejs/data/allthemodium/dimension/the_other.json
+++ b/kubejs/data/allthemodium/dimension/the_other.json
@@ -355,11 +355,6 @@
 						"separation": 1280,
 						"salt": 0
 					},
-					"iceandfire:mausoleum": {
-						"spacing": 8000,
-						"separation": 8000,
-						"salt": 0
-					},
 					"iceandfire:graveyard": {
 						"spacing": 2560,
 						"separation": 1280,

--- a/kubejs/data/allthemodium/dimension/the_other.json
+++ b/kubejs/data/allthemodium/dimension/the_other.json
@@ -360,7 +360,7 @@
 						"separation": 8000,
 						"salt": 0
 					},
-					"iceandfire:gorgon_temple": {
+					"iceandfire:graveyard": {
 						"spacing": 2560,
 						"separation": 1280,
 						"salt": 0

--- a/kubejs/data/allthemodium/dimension/the_other.json
+++ b/kubejs/data/allthemodium/dimension/the_other.json
@@ -1,0 +1,372 @@
+{
+	"type": "allthemodium:the_other",
+	"generator": {
+		"type": "minecraft:noise",
+		"seed": 0,
+		"biome_source": {
+			"humidity_noise": {
+				"firstOctave": -7,
+				"amplitudes": [
+					1.0,
+					1.0
+				]
+			},
+			"altitude_noise": {
+				"firstOctave": -7,
+				"amplitudes": [
+					1.0,
+					1.0
+				]
+			},
+			"weirdness_noise": {
+				"firstOctave": -7,
+				"amplitudes": [
+					1.0,
+					1.0
+				]
+			},
+			"seed": 0,
+			"biomes": [
+				{
+					"parameters": {
+						"altitude": 0.0,
+						"weirdness": 0.1,
+						"offset": 0.0,
+						"temperature": 0.1,
+						"humidity": -0.1
+					},
+					"biome": "allthemodium:nether_wastes"
+				},
+				{
+					"parameters": {
+						"altitude": -0.5,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": -0.1,
+						"humidity": -0.7
+					},
+					"biome": "allthemodium:soul_sand_valley"
+				},
+				{
+					"parameters": {
+						"altitude": 0.0,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.0,
+						"humidity": 0.2
+					},
+					"biome": "allthemodium:badlands"
+				},
+
+				{
+					"parameters": {
+						"altitude": 0.9,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.9,
+						"humidity": -0.5
+					},
+					"biome": "allthemodium:the_other"
+				},
+				{
+					"parameters": {
+						"altitude": 0.8,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": -0.7,
+						"humidity": 0.1
+					},
+					"biome": "allthemodium:mountain_edge"
+				},
+				{
+					"parameters": {
+						"altitude": 0.9,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": -0.6,
+						"humidity": 0.0
+					},
+					"biome": "allthemodium:mountains"
+				},
+				{
+					"parameters": {
+						"altitude": 0.8,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.0,
+						"humidity": 0.4
+					},
+					"biome": "allthemodium:gravelly_mountains"
+				},
+				{
+					"parameters": {
+						"altitude": 0.8,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.0,
+						"humidity": 0.3
+					},
+					"biome": "allthemodium:modified_gravelly_mountains"
+				},
+				{
+					"parameters": {
+						"altitude": -0.3,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.9,
+						"humidity": 0.0
+					},
+					"biome": "allthemodium:desert"
+				},
+				{
+					"parameters": {
+						"altitude": 0.2,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.0,
+						"humidity": 0.1
+					},
+					"biome": "allthemodium:eroded_badlands"
+				},
+				{
+					"parameters": {
+						"altitude": 0.0,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.3,
+						"humidity": 0.9
+					},
+					"biome": "allthemodium:crimson_forest"
+				},
+				{
+					"parameters": {
+						"altitude": 0.0,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.5,
+						"humidity": 0.7
+					},
+					"biome": "allthemodium:warped_forest"
+				},
+				{
+					"parameters": {
+						"altitude": 0.0,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.2,
+						"humidity": -0.1
+					},
+					"biome": "allthemodium:modified_badlands_plateau"
+				},
+				{
+					"parameters": {
+						"altitude": 0.0,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.8,
+						"humidity": -0.6
+					},
+					"biome": "allthemodium:desert_hills"
+				},
+				{
+					"parameters": {
+						"altitude": 0.0,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.4,
+						"humidity": -0.5
+					},
+					"biome": "allthemodium:badlands_plateau"
+				},
+				{
+					"parameters": {
+						"altitude": -0.2,
+						"weirdness": 0.0,
+						"offset": 0.0,
+						"temperature": 0.5,
+						"humidity": -0.6
+					},
+					"biome": "allthemodium:basalt_deltas"
+				}
+			],
+			"temperature_noise": {
+				"firstOctave": -7,
+				"amplitudes": [
+					1.0,
+					1.0
+				]
+			},
+			"type": "minecraft:multi_noise"
+		},
+	"settings": {
+			"level": "",
+			"lakes": false,
+			"lava_lakes": true,
+			"features": [
+				[
+
+					"allthemodium:ore_vibranium",
+					"alltheores:ore_other_diamond",
+					"alltheores:ore_other_coal",
+					"alltheores:ore_other_iron",
+					"alltheores:ore_other_lapis",
+					"alltheores:ore_other_redstone",
+					"alltheores:ore_other_aluminum",
+					"alltheores:ore_other_copper",
+					"alltheores:ore_other_lead",
+					"alltheores:ore_other_nickel",
+					"alltheores:ore_other_osmium",
+					"alltheores:ore_other_platinum",
+					"alltheores:ore_other_silver",
+					"alltheores:ore_other_tin",
+					"alltheores:ore_other_uranium",
+					"alltheores:ore_other_zinc",
+					"minecraft:trees_giant"
+				]
+			],
+			"starts": [
+
+			],
+			"spawners": {
+				"monster": [
+					{
+						"type": "minecraft:wither_skeleton",
+						"weight": 40,
+						"minCount": 1,
+						"maxCount": 1
+					},
+					{
+						"type": "minecraft:blaze",
+						"weight": 100,
+						"minCount": 2,
+						"maxCount": 5
+					}
+
+				],
+				"creature": [
+				],
+				"ambient": [
+				],
+				"water_creature": [
+				],
+				"water_ambient": [
+				],
+				"misc": [
+				]
+			},
+			"sea_level": 125,
+			"bedrock_roof_position": -10,
+			"bedrock_floor_position": 0,
+			"disable_mob_generation": false,
+			"default_fluid": {
+				"Properties": {
+					"level": "8"
+				},
+				"Name": "allthemodium:molten_bluelava"
+			},
+			"default_block": {
+				"Name": "minecraft:netherrack"
+			},
+			"noise": {
+
+				"random_density_offset": true,
+				"density_factor": 1.0,
+				"density_offset": -0.071975,
+				"simplex_surface_noise": true,
+				"bottom_slide": {
+					"target": -30,
+					"size": 0,
+					"offset": 0
+				},
+				"size_horizontal": 1,
+				"size_vertical": 2,
+				"height": 256,
+				"sampling": {
+					"xz_scale": 0.9999999814507745,
+					"y_scale": 0.9999999814507745,
+					"xz_factor": 80.0,
+					"y_factor": 256.0
+				},
+				"top_slide": {
+					"target": -10,
+					"size": 3,
+					"offset": 0
+				}
+			},
+			"structures": {
+				"stronghold": {
+					"distance": 32,
+					"spread": 3,
+					"count": 128
+				},
+				"structures": {
+					"minecraft:buried_treasure": {
+						"spacing": 1,
+						"separation": 0,
+						"salt": 0
+					},
+					"minecraft:ruined_portal": {
+						"spacing": 40,
+						"separation": 15,
+						"salt": 34222645
+					},
+					"minecraft:mansion": {
+						"spacing": 80,
+						"separation": 20,
+						"salt": 10387319
+					},
+					"minecraft:nether_fossil": {
+						"spacing": 2,
+						"separation": 1,
+						"salt": 14357921
+					},
+					"minecraft:fortress": {
+						"spacing": 27,
+						"separation": 4,
+						"salt": 30084232
+					},
+					"minecraft:bastion_remnant": {
+						"spacing": 27,
+						"separation": 4,
+						"salt": 30084232
+					},
+					"minecraft:monument": {
+						"spacing": 32,
+						"separation": 5,
+						"salt": 10387313
+					},
+					"minecraft:pillager_outpost": {
+						"spacing": 32,
+						"separation": 8,
+						"salt": 165745296
+					},
+					"minecraft:mineshaft": {
+						"spacing": 1,
+						"separation": 0,
+						"salt": 0
+					},
+					"minecraft:village": {
+						"spacing": 32,
+						"separation": 8,
+						"salt": 10387312
+					},
+					"iceandfire:gorgon_temple": {
+						"spacing": 2560,
+						"separation": 1280,
+						"salt": 0
+					},
+					"iceandfire:mausoleum": {
+						"spacing": 8000,
+						"separation": 8000,
+						"salt": 0
+					},
+					"iceandfire:gorgon_temple": {
+						"spacing": 2560,
+						"separation": 1280,
+						"salt": 0
+					}
+				}
+			}
+		}
+	}
+}

--- a/kubejs/data/allthemodium/dimension/the_other.json
+++ b/kubejs/data/allthemodium/dimension/the_other.json
@@ -356,8 +356,8 @@
 						"salt": 0
 					},
 					"iceandfire:graveyard": {
-						"spacing": 2560,
-						"separation": 1280,
+						"spacing": 1280,
+						"separation": 640,
 						"salt": 0
 					}
 				}


### PR DESCRIPTION
This PR request contains two things.
1): Force generation of the following listed structures by overriding "the_other.json" file for generation of that dimension.
 - Gorgon Temples
 - Graveyards

2): Add RFToolsDimension Dimlets for all of The Other Biomes. Thus, one could have dragons flying around their own dimensions, or add more room to find ice&fire mobs, etc.

I assume this is fine.
