### PR TITLE
Fix T3+ apiary outputs for Awakened Bee

### DIFF
--- a/config/resourcefulbees/bees/bred/bees_ingot/Awakened.json
+++ b/config/resourcefulbees/bees/bred/bees_ingot/Awakened.json
@@ -3,7 +3,6 @@
 	"maxTimeInHive": 4800,
 	"traits": ["awakened"],
 	"hasHoneycomb": true,
-	"apiaryOutputTypes": ["COMB", "COMB", "COMB", "COMB", "COMB"],
 	"baseLayerTexture": "dragon/dragon_bee_primary",
 	"ColorData": {
 		"primaryColor": "#FF4C00",


### PR DESCRIPTION
Fixes higher tier apiaries outputting combs instead of blocks