### PR TITLE
Make PneumaticCraft recipes use #forge:plastic

### DIFF
--- a/kubejs/server_scripts/mod_specific/pneumaticcraft/pneumaticcraft.js
+++ b/kubejs/server_scripts/mod_specific/pneumaticcraft/pneumaticcraft.js
@@ -103,4 +103,48 @@ onEvent('recipes', e => {
     'count': 64
   }
   ], 'pneumaticcraft:creative_compressed_iron_block', 1, 4.9)
+  
+  //make plastic recipes take #forge:plastic
+  pressure([{
+	'type': 'pneumaticcraft:stacked_item',
+    'item': 'minecraft:gold_nugget',
+    'count': 3
+  },{
+	'type': 'pneumaticcraft:stacked_item',
+	'item': 'minecraft:redstone',
+	'count': 1
+  },{
+	'type': 'pneumaticcraft:stacked_item',
+	'tag': 'forge:plastic',
+	'count': 1
+  }], 'pneumaticcraft:transistor', 1, 1.0)
+  e.remove({id: 'pneumaticcraft:pressure_chamber/transistor'})
+  pressure([{
+	'type': 'pneumaticcraft:stacked_item',
+    'item': 'minecraft:gold_nugget',
+    'count': 2
+  },{
+	'type': 'pneumaticcraft:stacked_item',
+    'tag': 'forge:slimeballs',
+    'count': 1
+  },{
+	'type': 'pneumaticcraft:stacked_item',
+    'tag': 'forge:plastic',
+    'count': 1
+  }], 'pneumaticcraft:capacitor', 1, 1.0)
+  e.remove({id: 'pneumaticcraft:pressure_chamber/capacitor'})
+  pressure([{
+	'type': 'pneumaticcraft:stacked_item',
+    'item': 'minecraft:redstone_torch',
+    'count': 2
+  },{
+	'type': 'pneumaticcraft:stacked_item',
+    'item': 'minecraft:gold_nugget',
+    'count': 3
+  },{
+	'type': 'pneumaticcraft:stacked_item',
+    'tag': 'forge:plastic',
+    'count': 1
+  }], 'pneumaticcraft:empty_pcb', 3, 1.5)
+  e.remove({id: 'pneumaticcraft:pressure_chamber/empty_pcb'})
 })

--- a/kubejs/server_scripts/unify.js
+++ b/kubejs/server_scripts/unify.js
@@ -371,6 +371,7 @@ onEvent('recipes', e => {
   e.replaceInput('iceandfire:sapphire', '#forge:gems/sapphire')
   e.replaceInput('iceandfire:sapphire_block', '#forge:storage_blocks/sapphire')
   e.replaceInput('minecraft:stick', '#forge:rods/wooden')
+  e.replaceInput('pneumaticcraft:plastic','#forge:plastic')
 
   e.replaceOutput('immersivepetroleum:bitumen', 'thermal:bitumen')
   e.replaceOutput('lazierae2:coal_dust', 'mekanism:dust_coal')


### PR DESCRIPTION
Feel free to reject if it's intentional, but it's somewhat annoying to need PNC plastic for a memory stick