### PR TITLE
Resolve conflict between transparent plastic blocks and construction bricks

### DIFF
--- a/kubejs/server_scripts/mod_specific/pneumaticcraft/pneumaticcraft.js
+++ b/kubejs/server_scripts/mod_specific/pneumaticcraft/pneumaticcraft.js
@@ -147,4 +147,15 @@ onEvent('recipes', e => {
     'count': 1
   }], 'pneumaticcraft:empty_pcb', 3, 1.5)
   e.remove({ id: 'pneumaticcraft:pressure_chamber/empty_pcb' })
+
+  // change construction bricks to only take pneumaticcraft:plastic
+  function brickRecipe(color) {
+    e.shaped(`pneumaticcraft:plastic_brick_${color}`, ['PPP', 'PDP', 'PPP'], {
+      P: 'pneumaticcraft:plastic',
+      D: `#forge:dyes/${color}`
+    }).id(`kubejs:pneumaticcraft/plastic_brick_${color}`)
+    e.remove({ id: `pneumaticcraft:plastic_brick_${color}` })
+  }
+
+  colors.forEach(color => brickRecipe(color))
 })


### PR DESCRIPTION
Since many PneumaticCraft recipes now allow for any plastic to substitute for its plastic sheets, Mekanism's transparent plastic blocks are overridden by PC:R's construction bricks so that only the construction bricks can be crafted (both are 8 `forge:plastic`'s around a dye).

I've modified the construction brick recipe to only use PneumaticCraft plastic sheets to resolve this, as the Mekanism recipes already only take HDPE sheets.