### PR TITLE
Add null check to prevent an error when crafting ATM shards

### DIFF
--- a/kubejs/server_scripts/advanced_interactions/atm_shards.js
+++ b/kubejs/server_scripts/advanced_interactions/atm_shards.js
@@ -11,11 +11,10 @@ onEvent('block.left_click', e => {
         entities.forEach(entity => {
           if (entity.isFrame()) {
             frame = entity
-            return
           }
         })
 
-        if (frame.getItem() === 'atmadditions:atm_star') {
+        if (frame && frame.getItem() === 'atmadditions:atm_star') {
           frame.setItem('minecraft:air')
           e.world.spawnLightning(anvil.x, anvil.y, anvil.z, true)
           frame.kill()


### PR DESCRIPTION
Possibly fixes a rare error that can leave `frame` undefined and then error on `getItem`