### PR TITLE
Fix Charcoal Dupe

### DIFF
--- a/kubejs/server_scripts/mod_specific/chisel/chisel.js
+++ b/kubejs/server_scripts/mod_specific/chisel/chisel.js
@@ -1,0 +1,3 @@
+onEvent('recipes', e => {
+    e.remove({input:"minecraft:charcoal", output:"chisel:charcoal/raw"})
+})


### PR DESCRIPTION
This issue looks to resolve the charcoal dupe introduce by Chisel, and retain any charcoal recipes.

This was tested on a public server against ATM 1.8.24.

Closes: #3086 